### PR TITLE
Feature: add Python argument to specify OCaml binary

### DIFF
--- a/checker.py
+++ b/checker.py
@@ -46,7 +46,7 @@ if __name__ == '__main__':
     parser.add_argument("files", nargs='*', help="Path to IEC source files")
     parser.add_argument("--draw-cfg", type=str,
                         help="Save control flow graph image at the selected path")
-    parser.add_argument("-b","--binary", default="../output/bin/iec_checker",
+    parser.add_argument("-b","--binary", default=os.path.join("output", "bin", "iec_checker"),
                         help="File path to the OCaml binary")
     args = parser.parse_args()
     sys.exit(main(args.files, args.draw_cfg, args.binary))

--- a/checker.py
+++ b/checker.py
@@ -10,11 +10,12 @@ from python.dump import DumpManager  # noqa
 from python.plugins.cfg_plotter import CFGPlotter  # noqa
 
 
-def main(files: List[str], draw_cfg: str = ""):
+def main(files: List[str], draw_cfg: str = "",
+         binary: str = "../output/bin/iec_checker"):
     for f in files:
         if not os.path.isfile(f):
             continue
-        checker_warnings, rc = run_checker(f)
+        checker_warnings, rc = run_checker(f, binary)
         if rc != 0:
             print(f'Report for {f}:')
             for w in checker_warnings:
@@ -44,5 +45,7 @@ if __name__ == '__main__':
     parser.add_argument("files", nargs='*', help="Path to IEC source files")
     parser.add_argument("--draw-cfg", type=str,
                         help="Save control flow graph image at the selected path")
+    parser.add_argument("-b","--binary", default="../output/bin/iec_checker",
+                        help="File path to the OCaml binary")
     args = parser.parse_args()
-    sys.exit(main(args.files, args.draw_cfg))
+    sys.exit(main(args.files, args.draw_cfg, args.binary))

--- a/checker.py
+++ b/checker.py
@@ -41,7 +41,8 @@ def main(files: List[str], draw_cfg: str = "",
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        description='Static analysis for IEC 61131-3 programs.')
     parser.add_argument("files", nargs='*', help="Path to IEC source files")
     parser.add_argument("--draw-cfg", type=str,
                         help="Save control flow graph image at the selected path")

--- a/src/python/core.py
+++ b/src/python/core.py
@@ -19,12 +19,11 @@ def process_output(json_out: bytes) -> List[Warning]:
     return warnings
 
 
-def check_program(program: str) -> Tuple[List[Warning], int]:
+def check_program(program: str, binary: str) -> Tuple[List[Warning], int]:
     """Run iec-checker core and send given program source in stdin.
     This will create 'stdin.dump.json' dump file in a current directory.
     """
-    p = subprocess.Popen(["../output/bin/iec_checker",
-                          "-o", "json", "-q", "-d", "-"],
+    p = subprocess.Popen([binary, "-o", "json", "-q", "-d", "-"],
                          stdout=subprocess.PIPE,
                          stderr=subprocess.STDOUT,
                          stdin=subprocess.PIPE,
@@ -35,14 +34,13 @@ def check_program(program: str) -> Tuple[List[Warning], int]:
     return (warnings, p.returncode)
 
 
-def run_checker(file_path: str, *args) -> Tuple[List[Warning], int]:
+def run_checker(file_path: str, binary: str, *args) -> 
+                Tuple[List[Warning], int]:
     """Run iec-checker core for a given file.
 
     This will execute core inspections and generate JSON dump processed with
     plugins."""
-    p = subprocess.Popen(["../output/bin/iec_checker", "-o", "json", "-q", "-d",
-                          *args,
-                          file_path],
+    p = subprocess.Popen([binary, "-o", "json", "-q", "-d", *args, file_path],
                          stdout=subprocess.PIPE,
                          stderr=subprocess.STDOUT)
     p.wait()

--- a/src/python/core.py
+++ b/src/python/core.py
@@ -34,8 +34,8 @@ def check_program(program: str, binary: str) -> Tuple[List[Warning], int]:
     return (warnings, p.returncode)
 
 
-def run_checker(file_path: str, binary: str, *args) -> 
-                Tuple[List[Warning], int]:
+def run_checker(file_path: str, binary: str,
+                *args) -> Tuple[List[Warning], int]:
     """Run iec-checker core for a given file.
 
     This will execute core inspections and generate JSON dump processed with

--- a/src/python/core.py
+++ b/src/python/core.py
@@ -9,7 +9,7 @@ import ijson
 
 from .om import Warning
 
-binary_default = "../output/bin/iec_checker"
+binary_default = os.path.join("..", "output", "bin", "iec_checker")
 
 
 def process_output(json_out: bytes) -> List[Warning]:

--- a/src/python/core.py
+++ b/src/python/core.py
@@ -9,6 +9,8 @@ import ijson
 
 from .om import Warning
 
+binary_default = "../output/bin/iec_checker"
+
 
 def process_output(json_out: bytes) -> List[Warning]:
     warnings = []
@@ -19,7 +21,8 @@ def process_output(json_out: bytes) -> List[Warning]:
     return warnings
 
 
-def check_program(program: str, binary: str) -> Tuple[List[Warning], int]:
+def check_program(program: str,
+                  binary: str = binary_default) -> Tuple[List[Warning], int]:
     """Run iec-checker core and send given program source in stdin.
     This will create 'stdin.dump.json' dump file in a current directory.
     """
@@ -34,7 +37,7 @@ def check_program(program: str, binary: str) -> Tuple[List[Warning], int]:
     return (warnings, p.returncode)
 
 
-def run_checker(file_path: str, binary: str,
+def run_checker(file_path: str, binary: str = binary_default,
                 *args) -> Tuple[List[Warning], int]:
     """Run iec-checker core for a given file.
 


### PR DESCRIPTION
This PR adds an argument (`-b` or `--binary`) to the Python `checker.py` file to allow users to specify a custom location to the OCaml binary. This may be especially useful in Windows systems to allow the file to be stored at the user's discretion.

**Related Issue:**  #5 