### PR TITLE
feat(driver): Merge multiple files

### DIFF
--- a/src/core/dump.ml
+++ b/src/core/dump.ml
@@ -12,8 +12,7 @@ type dump_scheme = {
   cfgs: Cfg.t list;
 } [@@deriving to_yojson]
 
-let create_dump elements environments cfgs src_filename =
-  let dest_filename = Printf.sprintf "%s.dump.json" src_filename in
+let create_dump ~dst_file elements environments cfgs =
   let version = "0.1" in
   let functions =
     List.fold_left elements
@@ -50,4 +49,4 @@ let create_dump elements environments cfgs src_filename =
     environments;
     cfgs;
   } in
-  Yojson.Safe.to_file dest_filename (dump_scheme_to_yojson scheme)
+  Yojson.Safe.to_file dst_file (dump_scheme_to_yojson scheme)

--- a/src/core/dump.mli
+++ b/src/core/dump.mli
@@ -12,5 +12,5 @@ type dump_scheme = {
   cfgs: Cfg.t list;
 } [@@deriving to_yojson]
 
-val create_dump : S.iec_library_element list -> Env.t list -> Cfg.t list -> string (** source filename *) -> unit
+val create_dump : dst_file:string -> S.iec_library_element list -> Env.t list -> Cfg.t list -> unit
 (** [create_dump] Save input AST in a JSON file.  *)

--- a/src/python/core.py
+++ b/src/python/core.py
@@ -38,11 +38,11 @@ def check_program(program: str,
     return (warnings, p.returncode)
 
 
-def run_checker(file_path: str, binary: str = binary_default,
-                *args) -> Tuple[List[Warning], int]:
-    """Runs ``iec-checker`` for the given file.
+def run_checker(paths: str, binary: str = binary_default,
+                args: List[str] = []) -> Tuple[List[Warning], int]:
+    """Runs ``iec-checker`` for the given input files.
     This will execute analyses and generate JSON dump processed by plugins."""
-    p = subprocess.Popen([binary, "-o", "json", "-q", "-d", *args, file_path],
+    p = subprocess.Popen([binary, "-o", "json", "-q", "-d", *args, *paths],
                          stdout=subprocess.PIPE,
                          stderr=subprocess.STDOUT)
     p.wait()
@@ -51,11 +51,11 @@ def run_checker(file_path: str, binary: str = binary_default,
     return (warnings, p.returncode)
 
 
-def run_checker_full_out(file_path: str, binary: str = binary_default,
+def run_checker_full_out(paths: str, binary: str = binary_default,
                          *args) -> Tuple[int, str]:
-    """Runs ``iec-checker`` for the given file and captures its output.
+    """Runs ``iec-checker`` for the given input files and captures its output.
     No extra options will be set by default."""
-    p = subprocess.Popen([binary, *args, file_path],
+    p = subprocess.Popen([binary, *args, *paths],
                          stdout=subprocess.PIPE,
                          stderr=subprocess.STDOUT)
     p.wait()

--- a/test/st/merge-1.st
+++ b/test/st/merge-1.st
@@ -1,0 +1,5 @@
+TYPE example_struct :
+  STRUCT
+    Field : BOOL;
+  END_STRUCT
+END_TYPE

--- a/test/st/merge-2.st
+++ b/test/st/merge-2.st
@@ -1,0 +1,7 @@
+PROGRAM Program1
+  VAR
+    instance AT %MW500 : example_struct;
+  END_VAR
+
+  %MW500 := TRUE;
+END_PROGRAM

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9,7 +9,7 @@ from python.core import run_checker  # noqa
 
 def test_missing_file():
     f = 'st/foo.bar'
-    checker_warnings, rc = run_checker(f)
+    checker_warnings, rc = run_checker([f])
     assert rc == 1
     assert len(checker_warnings) == 1
     cv = checker_warnings[0]
@@ -32,5 +32,5 @@ def test_large_file():
         i := 0;
         END_PROGRAM
         """)
-    checker_warnings, rc = run_checker(fname)
+    checker_warnings, rc = run_checker([fname])
     os.remove(fname)

--- a/test/test_declaration_analysis.py
+++ b/test/test_declaration_analysis.py
@@ -10,7 +10,7 @@ from python.dump import DumpManager  # noqa
 def test_initialization_literal():
     f = 'st/declaration-analysis.st'
     fdump = f'{f}.dump.json'
-    checker_warnings, rc = run_checker(f)
+    checker_warnings, rc = run_checker([f])
     assert rc == 0
     assert len(checker_warnings) == 3
     cv = checker_warnings[0]

--- a/test/test_merge_files.py
+++ b/test/test_merge_files.py
@@ -1,0 +1,34 @@
+"""Test if the checker merges multiple input files correctly."""
+import sys
+import os
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(
+    os.path.abspath(__file__)), "../src"))
+from python.core import run_checker  # noqa
+from python.dump import DumpManager  # noqa
+
+
+def test_merge_multiple_files():
+    files = ['st/merge-1.st', 'st/merge-2.st']
+    fdump = 'merged-input.st.dump.json'
+    checker_warnings, rc = run_checker(files, args=["-m"])
+    assert rc == 0
+    with DumpManager(fdump):
+        pass
+
+def test_merge_multiple_files_different_order():
+    files = ['st/merge-2.st', 'st/merge-1.st']
+    fdump = 'merged-input.st.dump.json'
+    checker_warnings, rc = run_checker(files, args=["-m"])
+    assert rc == 0
+    with DumpManager(fdump):
+        pass
+
+def merge_is_disabled_for_a_single_input_file():
+    files = ['st/merge-2.st']
+    fdump = 'merged-input.st.dump.json'
+    checker_warnings, rc = run_checker(files, args=["-m"])
+    assert rc == 0
+    with DumpManager(fdump):
+        pass

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -11,7 +11,7 @@ from python.dump import DumpManager  # noqa
 def test_lexing_error():
     f = 'st/bad/lexing-error.st'
     fdump = f'{f}.dump.json'
-    checker_warnings, rc = run_checker(f)
+    checker_warnings, rc = run_checker([f])
     assert rc == 1
     assert len(checker_warnings) == 1
     cv = checker_warnings[0]
@@ -26,7 +26,7 @@ def test_parser_errors():
     for fname in os.listdir('st/bad/'):
         f = os.path.join('st/bad/', fname)
         fdump = f'{f}.dump.json'
-        checker_warnings, rc = run_checker(f)
+        checker_warnings, rc = run_checker([f])
         assert rc == 1, f"Incorrect exit code for {f}"
         assert len(checker_warnings) > 0
         with DumpManager(fdump):
@@ -39,7 +39,7 @@ def test_no_parser_errors():
             continue
         f = os.path.join('st/good/', fname)
         fdump = f'{f}.dump.json'
-        checker_warnings, rc = run_checker(f)
+        checker_warnings, rc = run_checker([f])
         assert rc == 0, f"Incorrect exit code for {f}"
         with DumpManager(fdump):
             pass
@@ -48,7 +48,7 @@ def test_no_parser_errors():
 def test_direct_variables():
     f = 'st/good/direct-variables.st'
     fdump = f'{f}.dump.json'
-    checker_warnings, rc = run_checker(f)
+    checker_warnings, rc = run_checker([f])
     assert rc == 0
     with DumpManager(fdump) as dm:
         _ = dm.scheme  # TODO

--- a/test/test_plcopen.py
+++ b/test/test_plcopen.py
@@ -11,7 +11,7 @@ from python.dump import DumpManager  # noqa
 def test_cp1():
     f = 'st/plcopen-cp1.st'
     fdump = f'{f}.dump.json'
-    checker_warnings, rc = run_checker(f)
+    checker_warnings, rc = run_checker([f])
     assert rc == 0
     checker_warnings.count('PLCOPEN-CP1') == 1
     with DumpManager(fdump):
@@ -21,7 +21,7 @@ def test_cp1():
 def test_cp3():
     f = 'st/plcopen-cp3.st'
     fdump = f'{f}.dump.json'
-    checker_warnings, rc = run_checker(f)
+    checker_warnings, rc = run_checker([f])
     assert rc == 0
     checker_warnings.count('PLCOPEN-CP3') == 8
     with DumpManager(fdump):
@@ -31,7 +31,7 @@ def test_cp3():
 def test_cp6():
     f = 'st/plcopen-cp6.st'
     fdump = f'{f}.dump.json'
-    checker_warnings, rc = run_checker(f)
+    checker_warnings, rc = run_checker([f])
     assert rc == 0
     checker_warnings.count('PLCOPEN-CP6') == 2
     with DumpManager(fdump):
@@ -41,7 +41,7 @@ def test_cp6():
 def test_cp8():
     f = 'st/plcopen-cp8.st'
     fdump = f'{f}.dump.json'
-    checker_warnings, rc = run_checker(f)
+    checker_warnings, rc = run_checker([f])
     assert rc == 0
     checker_warnings.count('PLCOPEN-CP8') == 4
     with DumpManager(fdump):
@@ -51,7 +51,7 @@ def test_cp8():
 def test_cp28():
     f = 'st/plcopen-cp28.st'
     fdump = f'{f}.dump.json'
-    checker_warnings, rc = run_checker(f)
+    checker_warnings, rc = run_checker([f])
     assert rc == 0
     checker_warnings.count('PLCOPEN-CP28') == 4
     with DumpManager(fdump):
@@ -61,7 +61,7 @@ def test_cp28():
 def test_cp13():
     f = 'st/plcopen-cp13.st'
     fdump = f'{f}.dump.json'
-    checker_warnings, rc = run_checker(f)
+    checker_warnings, rc = run_checker([f])
     assert rc == 0
     checker_warnings.count('PLCOPEN-CP13') == 3
     with DumpManager(fdump):
@@ -71,7 +71,7 @@ def test_cp13():
 def test_cp25():
     f = 'st/plcopen-cp25.st'
     fdump = f'{f}.dump.json'
-    checker_warnings, rc = run_checker(f)
+    checker_warnings, rc = run_checker([f])
     assert rc == 0
     checker_warnings.count('PLCOPEN-CP25') == 2
     with DumpManager(fdump):
@@ -81,7 +81,7 @@ def test_cp25():
 def test_l10():
     f = 'st/plcopen-l10.st'
     fdump = f'{f}.dump.json'
-    checker_warnings, rc = run_checker(f)
+    checker_warnings, rc = run_checker([f])
     assert rc == 0
     checker_warnings.count('PLCOPEN-L10') == 3
     with DumpManager(fdump):
@@ -91,7 +91,7 @@ def test_l10():
 def test_l17():
     f = 'st/plcopen-l17.st'
     fdump = f'{f}.dump.json'
-    checker_warnings, rc = run_checker(f)
+    checker_warnings, rc = run_checker([f])
     assert rc == 0
     assert len(checker_warnings) >= 1
     cv = checker_warnings[1]
@@ -105,7 +105,7 @@ def test_l17():
 def test_n3():
     f = 'st/plcopen-n3.st'
     fdump = f'{f}.dump.json'
-    checker_warnings, rc = run_checker(f)
+    checker_warnings, rc = run_checker([f])
     assert rc == 0
     assert len(checker_warnings) >= 1
     cv = checker_warnings[5]
@@ -119,7 +119,7 @@ def test_n3():
 def test_cp9():
     f = 'st/plcopen-cp9.st'
     fdump = f'{f}.dump.json'
-    warns, rc = run_checker(f)
+    warns, rc = run_checker([f])
     assert rc == 0
     assert len(filter_warns(warns, 'PLCOPEN-CP9')) == 2
     with DumpManager(fdump):

--- a/test/test_plcopen_xml.py
+++ b/test/test_plcopen_xml.py
@@ -13,7 +13,7 @@ from python.dump import DumpManager  # noqa
 def test_no_parser_errors():
     f = os.path.join('./test/plcopen/example.xml')
     fdump = f'{f}.dump.json'
-    checker_warnings, rc = run_checker(f, '-i', 'xml')
+    checker_warnings, rc = run_checker([f], '-i', 'xml')
     assert rc == 0, f"Incorrect exit code for {f}"
     with DumpManager(fdump):
         pass

--- a/test/test_selxml.py
+++ b/test/test_selxml.py
@@ -10,7 +10,7 @@ from python.dump import DumpManager  # noqa
 
 
 def test_sel_rtac():
-    rc, out = run_checker_full_out('selxml/SEL_RTAC/', binary_default, "-v", "-i", "selxml")
+    rc, out = run_checker_full_out(['selxml/SEL_RTAC/'], binary_default, "-v", "-i", "selxml")
     assert rc == 0
     assert("Parsing selxml/SEL_RTAC/ProjSpace_MAIN_POU.xml" in out)
     assert("Parsing selxml/SEL_RTAC/Tag Processor.xml" in out)
@@ -23,7 +23,7 @@ def test_sel_rtac():
 def test_recurse_dirs():
     """Test whether the checker will recursively looking up for files in the
     nested directories."""
-    rc, out = run_checker_full_out('selxml', binary_default, "-v", "-i", "selxml")
+    rc, out = run_checker_full_out(['selxml'], binary_default, "-v", "-i", "selxml")
     assert rc == 0
     assert("Parsing selxml/SEL_RTAC/ProjSpace_MAIN_POU.xml" in out)
     assert("Parsing selxml/SEL_RTAC/Tag Processor.xml" in out)

--- a/test/test_zerodiv.py
+++ b/test/test_zerodiv.py
@@ -10,7 +10,7 @@ from python.dump import DumpManager  # noqa
 def test_zerodiv():
     f = 'st/zero-division.st'
     fdump = f'{f}.dump.json'
-    checker_warnings, rc = run_checker(f)
+    checker_warnings, rc = run_checker([f])
     assert rc == 0
     checker_warnings.count('ZeroDivision') == 2
     with DumpManager(fdump):


### PR DESCRIPTION
Some industrial automation IDEs force the source code to be splitted in a few files. For example, they might require that types, global variables and POUs must be defined in separate files.

To make it easier to use the checker for such projects the `-merge` option was introduced. It simply merges the content of all input files to a single temporary file before running analysis.

Resolves #20