### PR TITLE
Fix: Allow totally whitespace in fb_body/fc_body.

### DIFF
--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -64,6 +64,10 @@
   let mk_var_use_dir dv =
     let var_use = Syntax.VarUse.create_dir dv Syntax.VarUse.Elementary in
     var_use
+  
+  let stmt_list_of_option = function
+    | None -> []
+    | Some l -> l
 %}
 
 (* {{{ Tokens *)
@@ -1340,7 +1344,8 @@ let function_ty :=
   | ~ = derived_type_access; <Syntax.TyDerived>
 
 let func_body :=
-  | ~ = stmt_list; <>
+  | sl_opt = option(stmt_list);
+  { stmt_list_of_option sl_opt }
   (* Allow empty body of function with {} *)
   | T_LBRACE; T_RBRACE; { [] }
 (* }}} *)
@@ -1372,7 +1377,8 @@ let fb_decl :=
   { Syntax.{ id; variables = vds; statements = ss } }
 
 let fb_body :=
-  | ~ = stmt_list; <>
+  | sl_opt = option(stmt_list);
+  { stmt_list_of_option sl_opt }
   (* Allow an empty body of the function block with {} *)
   | T_LBRACE; T_RBRACE; { [] }
 


### PR DESCRIPTION
Hello, dear contributers. I used iec-checker serveral months ago. I have identified some issues in the lexical analysis and syntax parsing processes and have made targeted modifications. If you don't mind, I will submit some PRs to this repository. I mainly use the CODESYS 3.5.20.40 (V3.5) SP20 Patch 4 as vendor IDE.

This PR changes only one thing.

For function bodies and function block bodies, an empty statement list is allowed.

According to the IEC 61131-3 grammar, the bodies of function blocks and functions are defined as follows:
```
FB_Body   : SFC | Ladder_Diagram | FB_Diagram | Instruction_List | Stmt_List | Other_Languages;
Func_Body : Ladder_Diagram | FB_Diagram | Instruction_List | Stmt_List | Other_Languages;
...
Stmt_List : (Stmt? ';')*;
```

However, in practice, when the statement list in a function body or function block body contains only whitespace, CODESYS does not report a parsing error. For example, the following function is accepted:
```
FUNCTION Test : INT
VAR_INPUT
    x : INT;
END_VAR
END_FUNCTION
```

IEC-Checker currently rejects this case during parsing, while CODESYS accepts it. In other words, the current parser behavior is stricter.

It makes a minimal parser change to allow an empty statement list consisting of only whitespace in FUNCTION and FUNCTION_BLOCK bodies, so that IEC-Checker is more consistent with actual vendor behavior. The change is limited to this case only and does not modify the parsing behavior for non-empty statement lists.
