### PR TITLE
Fix: Allow any statement to be empty.

### DIFF
--- a/src/core/ast_util.ml
+++ b/src/core/ast_util.ml
@@ -73,6 +73,7 @@ let rec stmts_to_list stmt =
       in
       [stmt] @ func_params_stmts
     end
+  | S.StmEmpty _ -> [ stmt ]
 
 let get_pou_stmts = function
   | S.IECFunction (_, f) ->
@@ -152,6 +153,7 @@ let rec get_stmt_exprs stmt =
       (get_nested func_params_stmts)
     end
   | S.StmExit _ | S.StmContinue _ | S.StmReturn _ -> []
+  | S.StmEmpty _ -> []
 
 let get_pou_exprs elem =
   get_pou_stmts elem
@@ -261,6 +263,7 @@ let filter_exprs ~f elem =
         |> List.append acc
       end
     | S.StmExit _ | S.StmContinue _ | S.StmReturn _ -> acc
+    | S.StmEmpty _ -> acc
   in
   let all_stmts = get_pou_stmts elem in
   List.fold_left

--- a/src/core/cfg.ml
+++ b/src/core/cfg.ml
@@ -283,6 +283,9 @@ let fill_bbs_map (cfg : t) (stmts : S.statement list) : (unit) =
           link_func_calls_stmts expr |> ignore;
           (bbs_pred_ids, Some(created_bb.id))
         end
+      | S.StmEmpty _ ->
+        (* Empty / no-op statement: nothing to process, keep current BB as previous *)
+        (bbs_pred_ids, Some(created_bb.id))
       | S.StmElsif (_, cond_stmt, body_stmts) ->
         begin
           (* Process [cond_stmt]. *)

--- a/src/core/syntax.ml
+++ b/src/core/syntax.ml
@@ -505,6 +505,8 @@ and statement =
                  statement list * (** body *)
                  statement (** condition *)
                  [@name "Repeat"]
+  | StmEmpty of TI.t
+               [@name "Empty"]
   | StmExit of TI.t
                [@name "Exit"]
   | StmContinue of TI.t
@@ -546,6 +548,7 @@ let stmt_get_ti = function
   | StmFor (ti,_,_) -> ti
   | StmWhile (ti,_,_) -> ti
   | StmRepeat (ti,_,_) -> ti
+  | StmEmpty (ti) -> ti
   | StmExit (ti) -> ti
   | StmContinue (ti) -> ti
   | StmReturn (ti) -> ti
@@ -563,6 +566,7 @@ let stmt_to_string = function
   | StmFor _ -> "For"
   | StmWhile _ -> "While"
   | StmRepeat _ -> "Repeat"
+  | StmEmpty _ -> "Empty"
   | StmExit _ -> "Exit"
   | StmContinue _ -> "Continue"
   | StmReturn _ -> "Return"

--- a/src/core/syntax.mli
+++ b/src/core/syntax.mli
@@ -373,6 +373,8 @@ and statement =
                  statement list * (** body *)
                  statement (** condition *)
                  [@name "Repeat"]
+  | StmEmpty of TI.t
+               [@name "Empty"]
   | StmExit of TI.t
                [@name "Exit"]
   | StmContinue of TI.t

--- a/src/lib/plcopen_l13.ml
+++ b/src/lib/plcopen_l13.ml
@@ -53,7 +53,7 @@ and find_var_in_stmt var_name = function
     find_var_in_stmts var_name body @ find_var_in_stmt var_name cond
   | S.StmFuncCall (_, _, fps) ->
     List.concat_map fps ~f:(fun fp -> find_var_in_stmt var_name fp.stmt)
-  | S.StmExit _ | S.StmContinue _ | S.StmReturn _ -> []
+  | S.StmExit _ | S.StmContinue _ | S.StmReturn _ | S.StmEmpty _ -> []
 
 (** Scan a statement list for uses of [var_name].
     Stop when we hit a FOR that re-binds the same variable, since that
@@ -128,7 +128,7 @@ and check_nested = function
     check_stmt_list body @ check_nested cond
   | S.StmFuncCall (_, _, fps) ->
     List.concat_map fps ~f:(fun fp -> check_nested fp.stmt)
-  | S.StmExpr _ | S.StmExit _ | S.StmContinue _ | S.StmReturn _ -> []
+  | S.StmExpr _ | S.StmExit _ | S.StmContinue _ | S.StmReturn _ | S.StmEmpty _ -> []
 
 let do_check elems =
   List.concat_map elems ~f:(fun elem ->

--- a/src/lib/plcopen_l22.ml
+++ b/src/lib/plcopen_l22.ml
@@ -39,7 +39,7 @@ and find_in_stmt var_name = function
     find_assignments_to var_name body_ss @ find_in_stmt var_name cond_s
   | S.StmFuncCall (_, _, func_params) ->
     List.concat_map func_params ~f:(fun fp -> find_in_stmt var_name fp.stmt)
-  | S.StmExit _ | S.StmContinue _ | S.StmReturn _ -> []
+  | S.StmExit _ | S.StmContinue _ | S.StmReturn _ | S.StmEmpty _ -> []
 
 and find_in_expr var_name = function
   | S.ExprBin (ti, S.ExprVariable (_, vu), S.ASSIGN, _)
@@ -83,7 +83,7 @@ and check_stmt = function
     check_stmts body_ss @ check_stmt cond_s
   | S.StmFuncCall (_, _, func_params) ->
     List.concat_map func_params ~f:(fun fp -> check_stmt fp.stmt)
-  | S.StmExpr _ | S.StmExit _ | S.StmContinue _ | S.StmReturn _ -> []
+  | S.StmExpr _ | S.StmExit _ | S.StmContinue _ | S.StmReturn _ | S.StmEmpty _ -> []
 
 let do_check elems =
   List.concat_map elems ~f:(fun elem ->

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -1875,6 +1875,7 @@ let stmt :=
   | ~ = subprog_ctrl_stmt; <>
   | ~ = selection_stmt; <>
   | ~ = iteration_stmt; <>
+  | ~ = T_SEMICOLON; { Syntax.StmEmpty (TI.create_dummy ()) }
 
 let assign_stmt :=
   | v = variable; T_ASSIGN; e = expression;


### PR DESCRIPTION
In IEC 61131-3, the statement list is defined as follow:
```
Stmt_List : (Stmt? ';')*;
```
This indicates that empty statements are permitted in the standard, as the `*` symbol in the formula indicates repeated matching 0 to multiple times.

This PR adds the support for empty statement such as `;`.
