### PR TITLE
New feature: preserve the type information when parsing integer/real literals, and add support for bit string literal.

### DIFF
--- a/src/core/syntax.ml
+++ b/src/core/syntax.ml
@@ -463,9 +463,9 @@ and ref_value =
 [@@deriving to_yojson]
 
 and constant =
-  | CInteger of TI.t * int           [@name "Integer"]
+  | CInteger of TI.t * elementary_ty option * int    [@name "Integer"]
+  | CReal of TI.t * elementary_ty option * float     [@name "Real"]
   | CBool of TI.t * bool             [@name "Bool"]
-  | CReal of TI.t * float            [@name "Real"]
   | CString of TI.t * string         [@name "String"]
   | CPointer of TI.t * ref_value     [@name "Pointer"]
   | CTimeValue of TI.t * TimeValue.t [@name "TimeValue"]
@@ -589,9 +589,9 @@ let expr_get_id e =
 (* {{{ Functions to work with constants *)
 let c_is_zero c =
   match c with
-  | CInteger (_, v) -> phys_equal v 0
+  | CInteger (_, _, v) -> phys_equal v 0
   | CBool (_, v) -> phys_equal v false
-  | CReal (_, v) -> phys_equal v 0.0
+  | CReal (_, _, v) -> phys_equal v 0.0
   | CString _ -> false
   | CPointer (_, v) -> begin
       match v with
@@ -604,9 +604,9 @@ let c_is_zero c =
 
 let c_get_str_value c =
   match c with
-  | CInteger (_, v) -> string_of_int v
+  | CInteger (_, _, v) -> string_of_int v
   | CBool (_, v) -> string_of_bool v
-  | CReal (_, v) -> string_of_float v
+  | CReal (_, _, v) -> string_of_float v
   | CString (_, v) -> v
   | CPointer (_, v) -> begin
       match v with
@@ -620,9 +620,9 @@ let c_get_str_value c =
 
 let c_get_ti c =
   match c with
-  | CInteger (ti, _) -> ti
+  | CInteger (ti, _, _) -> ti
   | CBool (ti, _) -> ti
-  | CReal (ti, _) -> ti
+  | CReal (ti, _, _) -> ti
   | CString (ti, _) -> ti
   | CPointer (ti, _) -> ti
   | CTimeValue (ti, _) -> ti
@@ -631,15 +631,15 @@ let c_get_ti c =
 
 let c_add c1 c2 =
   match (c1, c2) with
-  | CInteger (ti, v1), CInteger (_, v2) ->
+  | CInteger (ti, _, v1), CInteger (_, _, v2) ->
     let v = v1 + v2 in
-    CInteger (ti, v)
+    CInteger (ti, None, v)
   | CBool (ti, v1), CBool (_, v2) ->
     let v = v1 || v2 in
     CBool (ti, v)
-  | CReal (ti, v1), CReal (_, v2) ->
+  | CReal (ti, _, v1), CReal (_, _, v2) ->
     let v = v1 +. v2 in
-    CReal (ti, v)
+    CReal (ti, None, v)
   | CString (ti, v1), CString (_, v2) ->
     let v = v1 ^ v2 in
     CString (ti, v)

--- a/src/core/syntax.ml
+++ b/src/core/syntax.ml
@@ -465,6 +465,7 @@ and ref_value =
 and constant =
   | CInteger of TI.t * elementary_ty option * int    [@name "Integer"]
   | CReal of TI.t * elementary_ty option * float     [@name "Real"]
+  | CBitString of TI.t * elementary_ty option * int  [@name "BitString"]
   | CBool of TI.t * bool             [@name "Bool"]
   | CString of TI.t * string         [@name "String"]
   | CPointer of TI.t * ref_value     [@name "Pointer"]
@@ -590,6 +591,7 @@ let expr_get_id e =
 let c_is_zero c =
   match c with
   | CInteger (_, _, v) -> phys_equal v 0
+  | CBitString (_, _, v) -> phys_equal v 0
   | CBool (_, v) -> phys_equal v false
   | CReal (_, _, v) -> phys_equal v 0.0
   | CString _ -> false
@@ -605,6 +607,7 @@ let c_is_zero c =
 let c_get_str_value c =
   match c with
   | CInteger (_, _, v) -> string_of_int v
+  | CBitString (_, _, v) -> string_of_int v
   | CBool (_, v) -> string_of_bool v
   | CReal (_, _, v) -> string_of_float v
   | CString (_, v) -> v
@@ -621,6 +624,7 @@ let c_get_str_value c =
 let c_get_ti c =
   match c with
   | CInteger (ti, _, _) -> ti
+  | CBitString (ti, _, _) -> ti
   | CBool (ti, _) -> ti
   | CReal (ti, _, _) -> ti
   | CString (ti, _) -> ti
@@ -634,6 +638,9 @@ let c_add c1 c2 =
   | CInteger (ti, _, v1), CInteger (_, _, v2) ->
     let v = v1 + v2 in
     CInteger (ti, None, v)
+  | CBitString (ti, _, v1), CBitString (_, _, v2) ->
+    let v = v1 lor v2 in
+    CBitString (ti, None, v)
   | CBool (ti, v1), CBool (_, v2) ->
     let v = v1 || v2 in
     CBool (ti, v)

--- a/src/core/syntax.mli
+++ b/src/core/syntax.mli
@@ -333,6 +333,7 @@ and ref_value =
 and constant =
   | CInteger of TI.t * elementary_ty option * int    [@name "Integer"]
   | CReal of TI.t * elementary_ty option * float     [@name "Real"]
+  | CBitString of TI.t * elementary_ty option * int  [@name "BitString"]
   | CBool of TI.t * bool             [@name "Bool"]
   | CString of TI.t * string         [@name "String"]
   | CPointer of TI.t * ref_value     [@name "Pointer"]

--- a/src/core/syntax.mli
+++ b/src/core/syntax.mli
@@ -331,9 +331,9 @@ and ref_value =
 [@@deriving to_yojson]
 
 and constant =
-  | CInteger of TI.t * int           [@name "Integer"]
+  | CInteger of TI.t * elementary_ty option * int    [@name "Integer"]
+  | CReal of TI.t * elementary_ty option * float     [@name "Real"]
   | CBool of TI.t * bool             [@name "Bool"]
-  | CReal of TI.t * float            [@name "Real"]
   | CString of TI.t * string         [@name "String"]
   | CPointer of TI.t * ref_value     [@name "Pointer"]
   | CTimeValue of TI.t * TimeValue.t [@name "TimeValue"]

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -30,12 +30,6 @@
 
   let cint_mk ?ty t =
     let (v, ti) = t in
-    (* Debug Printing *)
-    (*let ty_str = match ty with
-      | Some ty -> Printf.sprintf "Some(%s)" (Syntax.ety_to_string ty)
-      | None -> "None"
-    in
-    Printf.eprintf "[PARSER] CInteger: value=%d, elementary_ty=%s\n" v ty_str;*)
     Syntax.CInteger(ti, ty, v)
 
   let creal_mk ?ty t =

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -343,7 +343,6 @@ let constant :=
     let ti = Syntax.c_get_ti c in
     Syntax.ExprConstant(ti, c)
   }
-  (* | ~ = bit_str_literal <Syntax.ExprConstant> *)
   | c = bit_str_literal;
   {
     let ti = Syntax.c_get_ti c in

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -48,6 +48,17 @@
     Printf.eprintf "[PARSER] CReal: value=%s, elementary_ty=%s\n" 
       (string_of_float v) ty_str;*)
     Syntax.CReal(ti, ty, v)
+  
+  let cbitstr_mk ?ty t =
+    let (v, ti) = t in
+    (* Debug Printing *)
+    (*let ty_str = match ty with
+      | Some ty -> Printf.sprintf "Some(%s)" (Syntax.ety_to_string ty)
+      | None -> "None"
+    in
+    Printf.eprintf "[PARSER] CBitString: value=%s, elementary_ty=%s\n"
+      (string_of_int v) ty_str;*)
+    Syntax.CBitString(ti, ty, v)
 
   let ctime_mk fn t =
     let (v, ti) = t in
@@ -333,6 +344,11 @@ let constant :=
     Syntax.ExprConstant(ti, c)
   }
   (* | ~ = bit_str_literal <Syntax.ExprConstant> *)
+  | c = bit_str_literal;
+  {
+    let ti = Syntax.c_get_ti c in
+    Syntax.ExprConstant(ti, c)
+  }
   | c = bool_literal;
   {
     let ti = Syntax.c_get_ti c in
@@ -344,7 +360,7 @@ let numeric_literal :=
   | ~ = real_literal; <>
 
 let int_literal :=
-  // Only constants with type-prefix need to input a specific integer type for later inference
+  (* Only constants with type-prefix need to input a specific integer type for later inference *)
   | ty = int_type_name; T_SHARP; (v, ti) = raw_signed_int;
   { cint_mk ~ty (v, ti) }
   | ty = int_type_name; T_SHARP; (v, ti) = raw_binary_int;
@@ -444,6 +460,16 @@ let real_literal :=
   { creal_mk (creal_inv (creal_conv_fp vr)) }
 
 (* bit_str_literal: *)
+let bit_str_literal :=
+  (* Bit string literals with type-prefix need to input a specific integer type for later inference *)
+  | ty = multibits_type_name; T_SHARP; (v, ti) = raw_unsigned_int;
+    { cbitstr_mk ~ty (v, ti)}
+  | ty = multibits_type_name; T_SHARP; (v, ti) = raw_binary_int;
+    { cbitstr_mk ~ty (v, ti) }
+  | ty = multibits_type_name; T_SHARP; (v, ti) = raw_octal_int;
+    { cbitstr_mk ~ty (v, ti) }
+  | ty = multibits_type_name; T_SHARP; (v, ti) = raw_hex_int;
+    { cbitstr_mk ~ty (v, ti) }
 
 let bool_literal :=
   (* BOOL#<value> rules are implemented in lexer *)

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -38,13 +38,6 @@
   
   let cbitstr_mk ?ty t =
     let (v, ti) = t in
-    (* Debug Printing *)
-    (*let ty_str = match ty with
-      | Some ty -> Printf.sprintf "Some(%s)" (Syntax.ety_to_string ty)
-      | None -> "None"
-    in
-    Printf.eprintf "[PARSER] CBitString: value=%s, elementary_ty=%s\n"
-      (string_of_int v) ty_str;*)
     Syntax.CBitString(ti, ty, v)
 
   let ctime_mk fn t =

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -34,13 +34,6 @@
 
   let creal_mk ?ty t =
     let (v, ti) = t in
-    (* Debug Printing *)
-    (*let ty_str = match ty with
-      | Some ty -> Printf.sprintf "Some(%s)" (Syntax.ety_to_string ty)
-      | None -> "None"
-    in
-    Printf.eprintf "[PARSER] CReal: value=%s, elementary_ty=%s\n" 
-      (string_of_float v) ty_str;*)
     Syntax.CReal(ti, ty, v)
   
   let cbitstr_mk ?ty t =

--- a/src/parser/parser.mly
+++ b/src/parser/parser.mly
@@ -28,9 +28,26 @@
     let vv = float_of_string vfp in
     (vv, ti)
 
-  let creal_mk t =
+  let cint_mk ?ty t =
     let (v, ti) = t in
-    Syntax.CReal(ti, v)
+    (* Debug Printing *)
+    (*let ty_str = match ty with
+      | Some ty -> Printf.sprintf "Some(%s)" (Syntax.ety_to_string ty)
+      | None -> "None"
+    in
+    Printf.eprintf "[PARSER] CInteger: value=%d, elementary_ty=%s\n" v ty_str;*)
+    Syntax.CInteger(ti, ty, v)
+
+  let creal_mk ?ty t =
+    let (v, ti) = t in
+    (* Debug Printing *)
+    (*let ty_str = match ty with
+      | Some ty -> Printf.sprintf "Some(%s)" (Syntax.ety_to_string ty)
+      | None -> "None"
+    in
+    Printf.eprintf "[PARSER] CReal: value=%s, elementary_ty=%s\n" 
+      (string_of_float v) ty_str;*)
+    Syntax.CReal(ti, ty, v)
 
   let ctime_mk fn t =
     let (v, ti) = t in
@@ -38,11 +55,11 @@
     Syntax.CTimeValue(ti, tv)
 
   let c_get_int = function
-    | Syntax.CInteger (_,v) -> Some(v)
+    | Syntax.CInteger (_, _, v) -> Some(v)
     | _ -> None
 
   let c_get_int_exn = function
-    | Syntax.CInteger (_, v) -> v
+    | Syntax.CInteger (_, _, v) -> v
     | _ -> assert false
 
   let mk_global_decl (sym_var : Syntax.SymVar.t) =
@@ -327,60 +344,85 @@ let numeric_literal :=
   | ~ = real_literal; <>
 
 let int_literal :=
-  | int_type_name; T_SHARP; ~ = signed_int; <>
-  | int_type_name; T_SHARP; ~ = binary_int; <>
-  | int_type_name; T_SHARP; ~ = octal_int; <>
-  | int_type_name; T_SHARP; ~ = hex_int; <>
+  // Only constants with type-prefix need to input a specific integer type for later inference
+  | ty = int_type_name; T_SHARP; (v, ti) = raw_signed_int;
+  { cint_mk ~ty (v, ti) }
+  | ty = int_type_name; T_SHARP; (v, ti) = raw_binary_int;
+  { cint_mk ~ty (v, ti) }
+  | ty = int_type_name; T_SHARP; (v, ti) = raw_octal_int;
+  { cint_mk ~ty (v, ti) }
+  | ty = int_type_name; T_SHARP; (v, ti) = raw_hex_int;
+  { cint_mk ~ty (v, ti) }
   | ~ = signed_int; <>
   | ~ = binary_int; <>
   | ~ = octal_int; <>
   | ~ = hex_int; <>
 
+let raw_unsigned_int :=
+  | vi = T_INTEGER; { vi }
+
+let raw_signed_int :=
+  | vi = raw_unsigned_int; { vi }
+  | T_PLUS; vi = raw_unsigned_int; { vi }
+  | T_MINUS; vi = T_INTEGER;
+  {
+    let (v, ti) = vi in
+    (-v, ti)
+  }
+
+let raw_binary_int :=
+  | vi = T_BINARY_INTEGER; { vi }
+
+let raw_octal_int :=
+  | vi = T_OCTAL_INTEGER; { vi }
+
+let raw_hex_int :=
+  | vi = T_HEX_INTEGER; { vi }
+
 let unsigned_int :=
   | vi = T_INTEGER;
   {
-    let (v, ti) = vi in
-    Syntax.CInteger(ti, v)
+    cint_mk vi
   }
 
 let signed_int :=
-  | ~ = unsigned_int; <>
-  | T_PLUS; ~ = unsigned_int; <>
+  | ~ = unsigned_int; <> 
+  | T_PLUS; res = T_INTEGER;
+  {
+    cint_mk res
+  }
   | T_MINUS; res = T_INTEGER;
   {
     let (v, ti) = res in
-    Syntax.CInteger(ti, -v)
+    cint_mk (-v, ti)
   }
 
 let binary_int :=
   | vi = T_BINARY_INTEGER;
   {
-    let (v, ti) = vi in
-    Syntax.CInteger(ti, v)
+    cint_mk vi
   }
 
 let octal_int :=
   | vi = T_OCTAL_INTEGER;
   {
-    let (v, ti) = vi in
-    Syntax.CInteger(ti, v)
+    cint_mk vi
   }
 
 let hex_int :=
   | vi = T_HEX_INTEGER;
   {
-    let (v, ti) = vi in
-    Syntax.CInteger(ti, v)
+    cint_mk vi
   }
 
 let real_literal :=
   (* With exponent *)
-  | real_type_name; T_SHARP; vr = T_REAL_VALUE;
-  { creal_mk vr }
-  | real_type_name; T_SHARP; T_PLUS; vr = T_REAL_VALUE;
-  { creal_mk vr }
-  | real_type_name; T_SHARP; T_MINUS; vr = T_REAL_VALUE;
-  { creal_mk (creal_inv vr) }
+  | ty = real_type_name; T_SHARP; vr = T_REAL_VALUE;
+  { creal_mk ~ty vr }
+  | ty = real_type_name; T_SHARP; T_PLUS; vr = T_REAL_VALUE;
+  { creal_mk ~ty vr }
+  | ty = real_type_name; T_SHARP; T_MINUS; vr = T_REAL_VALUE;
+  { creal_mk ~ty (creal_inv vr) }
   | vr = T_REAL_VALUE;
   { creal_mk vr }
   | T_PLUS; vr = T_REAL_VALUE;
@@ -388,12 +430,12 @@ let real_literal :=
   | T_MINUS; vr = T_REAL_VALUE;
   { creal_mk (creal_inv vr) }
   (* Conversion from fixed-point token *)
-  | real_type_name; T_SHARP; vr = T_FIX_POINT_VALUE;
-  { creal_mk (creal_conv_fp vr) }
-  | real_type_name; T_SHARP; T_PLUS; vr = T_FIX_POINT_VALUE;
-  { creal_mk (creal_conv_fp vr) }
-  | real_type_name; T_SHARP; T_MINUS; vr = T_FIX_POINT_VALUE;
-  { creal_mk (creal_inv (creal_conv_fp vr)) }
+  | ty = real_type_name; T_SHARP; vr = T_FIX_POINT_VALUE;
+  { creal_mk ~ty (creal_conv_fp vr) }
+  | ty = real_type_name; T_SHARP; T_PLUS; vr = T_FIX_POINT_VALUE;
+  { creal_mk ~ty (creal_conv_fp vr) }
+  | ty = real_type_name; T_SHARP; T_MINUS; vr = T_FIX_POINT_VALUE;
+  { creal_mk ~ty (creal_inv (creal_conv_fp vr)) }
   | vr = T_FIX_POINT_VALUE;
   { creal_mk (creal_conv_fp vr) }
   | T_PLUS; vr = T_FIX_POINT_VALUE;
@@ -647,7 +689,7 @@ let string_type_name :=
 (* Helper rule for [string_type_name] *)
 let string_type_length :=
   | T_LBRACK; c = unsigned_int; T_RBRACK;
-  { match c with | Syntax.CInteger(_, v) -> v | _ -> assert false }
+  { match c with | Syntax.CInteger(_, _, v) -> v | _ -> assert false }
 
 let time_type_name :=
   | T_TIME;  { Syntax.TIME }
@@ -949,14 +991,14 @@ let array_elem_init :=
   | mul_c = unsigned_int; T_LBRACE; inval = option(array_elem_init_value); T_RBRACE;
   {
     let mk_int_const (i: int) =
-      Syntax.CInteger((TI.create_dummy ()), i)
+      Syntax.CInteger((TI.create_dummy ()), None, i)
     in
     let (inval_list : 'a list) = match inval with
       | Some v -> [v]
       | None -> [mk_int_const 0]
     in
     let (mul : int) = match mul_c with
-      | Syntax.CInteger(_, v) -> v
+      | Syntax.CInteger(_, _, v) -> v
       | _ -> assert false
     in
     let build_list i n =
@@ -2087,7 +2129,7 @@ let for_list :=
   {
     (* According 7.3.3.4.2 default STEP value is 1. *)
     let dti = TI.create_dummy () in
-    (e1, e2, Syntax.ExprConstant(dti, Syntax.CInteger(dti, 1)))
+    (e1, e2, Syntax.ExprConstant(dti, Syntax.CInteger(dti, None, 1)))
   }
 
 let while_stmt :=

--- a/test/st/good/literals.st
+++ b/test/st/good/literals.st
@@ -17,6 +17,10 @@ PROGRAM program0
     LD : INT;
 
     s : STRING;
+    x : BYTE;
+    y : WORD;
+    z : DWORD;
+    w : LWORD;
   END_VAR
 
   (* integer *)
@@ -116,6 +120,11 @@ PROGRAM program0
   s := STRING#"FOO";
   s := STRING#"BAR(*";
   s := STRING#'FOO';
+
+  x := BYTE#8#01;
+  y := WORD#16#1234;
+  z := DWORD#12345678;
+  w := LWORD#2#10100101001010101010101010101010;
 
 END_PROGRAM
 (* vim: set foldmethod=marker foldlevel=0 foldenable sw=2 tw=120 : *)

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -233,3 +233,139 @@ def test_array_types():
         ty = scheme.types[0]
         assert ty.name == 'BITS'
         assert ty.type == 'Array'
+
+def test_literal_elementary_ty_inference():
+    """Test that CInteger, CReal, CBitString literals carry the correct
+    elementary_ty when a type prefix is used, and carry None otherwise."""
+    fdump = 'stdin.dump.json'
+    _, rc = check_program("""
+        PROGRAM p
+        VAR
+            (* Variable declaration and initialization - type-prefixed literals should infer concrete types *)
+            a : INT := 123;           (* unprefixed integer → CInteger(ty=None) *)
+            b : REAL := 1.23;         (* unprefixed real → CReal(ty=None) *)
+            c : INT := INT#456;       (* INT# prefix → CInteger(ty=Some INT) *)
+            d : REAL := REAL#7.89;    (* REAL# prefix → CReal(ty=Some REAL) *)
+            e : UINT := UINT#789;     (* UINT# prefix → CInteger(ty=Some UINT) *)
+            f : LREAL := LREAL#12.34; (* LREAL# prefix → CReal(ty=Some LREAL) *)
+            g : BYTE := BYTE#16#FF;   (* BYTE# prefix → CBitString(ty=Some BYTE) *)
+            h : WORD := WORD#16#ABCD; (* WORD# prefix → CBitString(ty=Some WORD) *)
+        END_VAR
+
+        (* Literals in assignment statements - also need to be verified *)
+        a := 100;                    (* unprefixed → ty=None *)
+        c := DINT#1000;             (* DINT# prefix → ty=Some DINT *)
+        d := REAL#3.14;             (* REAL# prefix → ty=Some REAL *)
+        END_PROGRAM
+    """.replace('\n', ''))
+    assert rc == 0
+
+    with open(fdump, 'r') as fp:
+        scheme = json.load(fp)
+
+    # ------------------------------------------------------------------
+    # Auxiliary recursive lookup function: extract all constant node 
+    # information from the JSON tree
+    # ------------------------------------------------------------------
+    def find_constants(node):
+        """Traverse the JSON tree recursively, returning a list of all constant nodes.
+        
+        Each element is a (tag, type_str_or_none, value) tuple:
+          - tag: "Integer" / "Real" / "BitString"
+          - type_str_or_none: typename string list or None
+          - value: int or float
+        """
+        results = []
+        if isinstance(node, list):
+            # yojson encoding of variant: ["Tagname", arg0, arg1, arg2, ...]
+            # Three forms of constant:
+            #   ["Integer", ti_dict, type_opt, int_val]
+            #   ["Real",    ti_dict, type_opt, float_val]
+            #   ["BitString", ti_dict, type_opt, int_val]
+            if (len(node) >= 4 and isinstance(node[0], str)
+                    and node[0] in ("Integer", "Real", "BitString")):
+                tag = node[0]
+                # node[1] is Tok_info dict, node[2] is elementary_ty option, node[3] is value
+                ty_opt = node[2]  # Array of strings such as ["INT"] or None
+                val = node[3]
+                results.append((tag, ty_opt, val))
+            for child in node:
+                results.extend(find_constants(child))
+        elif isinstance(node, dict):
+            for child in node.values():
+                results.extend(find_constants(child))
+        return results
+
+    consts = find_constants(scheme)
+    assert len(consts) > 0, 'no constants found in dump'
+
+    # Build index by tag+value to assert
+    by_key = {(tag, val): ty_opt for tag, ty_opt, val in consts}
+
+    # ---- CInteger: no prefix → None -------------------------------------------------
+    assert ("Integer", 123) in by_key
+    assert by_key[("Integer", 123)] is None, \
+        f'bare integer 123 should have ty=None, got {by_key[("Integer", 123)]}'
+
+    assert ("Integer", 100) in by_key
+    assert by_key[("Integer", 100)] is None, \
+        f'bare integer 100 should have ty=None, got {by_key[("Integer", 100)]}'
+
+    print(by_key)
+    # ---- CInteger: type prefix → Some(typename) --------------------------------------
+    assert ("Integer", 456) in by_key
+    assert by_key[("Integer", 456)] == ["INT"], \
+        f'INT#456 should have ty="INT", got {by_key[("Integer", 456)]}'
+
+    assert ("Integer", 789) in by_key
+    assert by_key[("Integer", 789)] == ["UINT"], \
+        f'UINT#789 should have ty="UINT", got {by_key[("Integer", 789)]}'
+
+    assert ("Integer", 1000) in by_key
+    assert by_key[("Integer", 1000)] == ["DINT"], \
+        f'DINT#1000 should have ty="DINT", got {by_key[("Integer", 1000)]}'
+
+    # ---- CReal: no prefix → None ----------------------------------------------------
+    # 找 value≈1.23 的 Real
+    real_123 = [(tag, ty, v) for tag, ty, v in consts
+                if tag == "Real" and abs(v - 1.23) < 1e-9]
+    assert len(real_123) >= 1, 'no Real constant ~1.23 found'
+    _, ty_123, _ = real_123[0]
+    assert ty_123 is None, \
+        f'bare real 1.23 should have ty=None, got {ty_123}'
+
+    # ---- CReal: type prefix → Some(typename) ----------------------------------------
+    real_789 = [(tag, ty, v) for tag, ty, v in consts
+                if tag == "Real" and abs(v - 7.89) < 1e-9]
+    assert len(real_789) >= 1, 'no Real constant ~7.89 found'
+    _, ty_789, _ = real_789[0]
+    assert ty_789 == ["REAL"], \
+        f'REAL#7.89 should have ty="REAL", got {ty_789}'
+
+    real_1234 = [(tag, ty, v) for tag, ty, v in consts
+                 if tag == "Real" and abs(v - 12.34) < 1e-9]
+    assert len(real_1234) >= 1, 'no Real constant ~12.34 found'
+    _, ty_1234, _ = real_1234[0]
+    assert ty_1234 == ["LREAL"], \
+        f'LREAL#12.34 should have ty="LREAL", got {ty_1234}'
+
+    real_314 = [(tag, ty, v) for tag, ty, v in consts
+                if tag == "Real" and abs(v - 3.14) < 1e-9]
+    assert len(real_314) >= 1, 'no Real constant ~3.14 found'
+    _, ty_314, _ = real_314[0]
+    assert ty_314 == ["REAL"], \
+        f'REAL#3.14 should have ty="REAL", got {ty_314}'
+
+    # ---- CBitString: type prefix → Some(typename) -----------------------------------
+    # BYTE#16#FF → value is 255 (0xFF)
+    assert ("BitString", 255) in by_key, \
+        f'BYTE#16#FF (value=255) not found. All BitStrings: {[(t,v) for t,_,v in consts if t=="BitString"]}'
+    assert by_key[("BitString", 255)] == ["BYTE"], \
+        f'BYTE#16#FF should have ty="BYTE", got {by_key[("BitString", 255)]}'
+
+    # WORD#16#ABCD → value is 43981 (0xABCD)
+    assert ("BitString", 43981) in by_key, \
+        f'WORD#16#ABCD (value=43981) not found'
+    assert by_key[("BitString", 43981)] == ["WORD"], \
+        f'WORD#16#ABCD should have ty="WORD", got {by_key[("BitString", 43981)]}'
+    os.remove(fdump)

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -326,7 +326,7 @@ def test_literal_elementary_ty_inference():
         f'DINT#1000 should have ty="DINT", got {by_key[("Integer", 1000)]}'
 
     # ---- CReal: no prefix → None ----------------------------------------------------
-    # 找 value≈1.23 的 Real
+    # Find the Real that value≈1.23
     real_123 = [(tag, ty, v) for tag, ty, v in consts
                 if tag == "Real" and abs(v - 1.23) < 1e-9]
     assert len(real_123) >= 1, 'no Real constant ~1.23 found'


### PR DESCRIPTION
Actually I am not sure whether these two commits can be a new feature or not. 

This PR changes two things:

1. Concrete type information preservation.

In IEC 61131-3, there are lots of integer types like `SINT`, `UINT`, `LINT` ... and so on. When I decided to improve the checker lib plcopen_cp25, i found that IEC 61131-3 has given an implicit type conversion table and it has many integer types, float types and bit string types (See IEC 61131-3 3rd ver. figure 12), but iec-checker cannot provide these types at that time, so i did a few improvements... Anyway, it sounds a bit wordy saying these things, but it is interesting that when you found an issure, there was another implicit issue needed to be done.

When it comes a variable, it is easy to know its concrete type by definition. When it comes a literal, we also need to preserve the concrete type info if it is given explicitly, like `UINT#10`, `LINT#16#A400` ... 

2. Bit string literal parsing support.

Bit string literal like `WORD#10`, has been supported in this PR (the 2nd commit). Actually I found some related definitions in `parser.mly` like the `bit_str_type_name` and some comments like `(* bit_str_literal: *)` in it, somehow there was no definition of bit_str_literal so I added it.