### PR TITLE
Add Dockerfile to build/test in container.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+_build/
+__pycache__/
+.git/
+venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Opam Mirrors Based on OCaml 5.5
+FROM ocaml/opam:ubuntu-22.04-ocaml-5.5
+
+WORKDIR /home/opam/src
+
+COPY dune-project \
+  iec_checker.opam \
+  requirements.txt \
+  requirements-dev.txt \
+  /home/opam/src
+
+# Switch to root to modify apt sources and install 
+USER root
+
+# install python3 and graphviz
+RUN apt-get update && \
+    apt-get install -y python3 python3-pip python3-venv graphviz libgraphviz-dev pkg-config && \
+    rm -rf /var/lib/apt/lists/*
+
+USER opam
+
+# Install project dependencies (dune-project defines dependencies)
+# Note: opam install . By default installs both dependencies and the project itself.
+RUN opam install . --deps-only -y && \
+    opam clean -a -c -s --logs && \
+    pip install --no-cache-dir -r requirements-dev.txt && \
+    pip install --no-cache-dir -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build:
 test: build
 	@/bin/bash -c "source venv/bin/activate; \
 				   pushd test >/dev/null; \
-				   pytest; \
+				   python3 -m pytest; \
 				   popd >/dev/null; "
 
 doc:


### PR DESCRIPTION
I have done some containerization things before.

To build the docker image, just run the following command in project root directory:
```shell
# [image tag] can be given by user, such as iec-checker:latest
docker build . -t [image tag]
```

After building the image, run the following command in project root directory to build iec-checker:
```shell
# run for only project build/compile
docker run --rm \
     -v "$(pwd)":/home/opam/src \
     -u opam \
     -w /home/opam/src \
     [image tag] \
     /bin/bash -c 'make build'
```

For testing, also run in project root directory:
```bash
# run for testing
docker run --rm \
     -v "$(pwd)":/home/opam/src \
     -u opam \
     -w /home/opam/src \
     [image tag] \
     /bin/bash -c 'make test'
```

For testing in container, i did little change in Makefile, use `python3 -m pytest` instead of `pytest`, which is compatible to both container testing and host directly testing.