### PR TITLE
feat(detector): PLCOPEN-CP17: Usage of parameters shall match their declaration mode.

### DIFF
--- a/src/lib/checkerLib.ml
+++ b/src/lib/checkerLib.ml
@@ -26,6 +26,7 @@ let registered_detectors : Detector.t list = [
   Plcopen_cp9.detector;
   Plcopen_cp13.detector;
   Plcopen_cp16.detector;
+  Plcopen_cp17.detector;
   Plcopen_cp25.detector;
   Plcopen_cp26.detector;
   Plcopen_cp28.detector;

--- a/src/lib/plcopen_cp17.ml
+++ b/src/lib/plcopen_cp17.ml
@@ -22,6 +22,7 @@ module W = IECCheckerCore.Warn
 *)
 
 let rec collect_expr ~in_lhs (reads, writes) e =
+  (* in_lhs: Whether the expression is in the left-hand side of an assignment *)
   match e with
   | S.ExprVariable (_, vu) ->
     let name = S.VarUse.get_name vu in
@@ -34,8 +35,6 @@ let rec collect_expr ~in_lhs (reads, writes) e =
         let (r, w) = collect_expr ~in_lhs:true (reads, writes) lhs in
         collect_expr ~in_lhs:false (r, w) rhs
       | S.SENDTO ->
-        (* only consider output assignment in function call: var => output_var
-           here rhs is the receiver (written) *)
         collect_expr ~in_lhs:true (reads, writes) rhs
       | _ ->
         let (r, w) = collect_expr ~in_lhs:false (reads, writes) lhs in
@@ -76,8 +75,25 @@ and collect_stmt (reads, writes) stmt =
   | S.StmEmpty _ | S.StmExit _ | S.StmContinue _ | S.StmReturn _ ->
     (reads, writes)
   | S.StmFuncCall (_, _, params) ->
-    List.fold_left params ~init:(reads, writes) ~f:(fun acc (p : S.func_param_assign) ->
-        collect_stmt acc p.stmt)
+    List.fold_left params ~init:(reads, writes) ~f:collect_func_param_assign
+
+and collect_func_param_assign acc (p : S.func_param_assign) =
+  match p.stmt with
+  | S.StmExpr (_, S.ExprBin (_, _lhs, op, rhs)) ->
+    begin match op with
+    | S.ASSIGN | S.ASSIGN_REF ->
+      (* Consider input assignment in func call: var := input_var, here rhs is read *)
+      collect_expr ~in_lhs:false acc rhs
+    | S.SENDTO ->
+      (* Consider output assignment in func call: var => output_var, here rhs is written *)
+      collect_expr ~in_lhs:true acc rhs
+    | _ ->
+      (* Abnormal conditions, still treated as a regular statement *)
+      collect_stmt acc p.stmt
+    end
+  | _ ->
+    (* Non-standard parameter form, conservatively treated as a regular statement *)
+    collect_stmt acc p.stmt
 
 
 let get_pou_info elem =

--- a/src/lib/plcopen_cp17.ml
+++ b/src/lib/plcopen_cp17.ml
@@ -1,0 +1,164 @@
+open Core
+
+module S = IECCheckerCore.Syntax
+module W = IECCheckerCore.Warn
+
+(* Collect (read_vars, written_vars) from a statement.
+   A variable is considered "written" if it appears as LHS of an ASSIGN expr, "read" otherwise. 
+   However, it has problems:
+     A variable can be read in LHS, like subscripting: arr[i] := 0, here i is read, arr is written
+     In IEC 61131-3, the formal definitions related to "Subscript Variable Access" are:
+
+     Symbolic_Variable  : ( ( 'THIS' '.' ) | Namespace_Hierarchy '.' )? ( Var_Access | Multi_Elem_Var );
+     Var_Access         : Variable_Name | Ref_Deref; 
+     Multi_Elem_Var     : Var_Access (Subscript_List | Struct_Variable)+;
+     Subscript_List     : '[' Subscript ( ',' Subscript )* ']';
+     Subscript          : Expression;
+     ...
+     
+     So all variables in a `Subscript` are all read theoretically.
+     But because currently the parser has discarded the `Subscript` inside the `[]` when it is not a constant, 
+     we cannot distinguish the read/write of the variable in the `Subscript`.
+*)
+
+let rec collect_expr ~in_lhs (reads, writes) e =
+  match e with
+  | S.ExprVariable (_, vu) ->
+    let name = S.VarUse.get_name vu in
+    if in_lhs then (reads, name :: writes)
+    else (name :: reads, writes)
+  | S.ExprConstant _ -> (reads, writes)
+  | S.ExprBin (_, lhs, op, rhs) -> begin
+      match op with
+      | S.ASSIGN | S.ASSIGN_REF ->
+        let (r, w) = collect_expr ~in_lhs:true (reads, writes) lhs in
+        collect_expr ~in_lhs:false (r, w) rhs
+      | S.SENDTO ->
+        (* only consider output assignment in function call: var => output_var
+           here rhs is the receiver (written) *)
+        collect_expr ~in_lhs:true (reads, writes) rhs
+      | _ ->
+        let (r, w) = collect_expr ~in_lhs:false (reads, writes) lhs in
+        collect_expr ~in_lhs:false (r, w) rhs
+    end
+  | S.ExprUn (_, _, e') -> collect_expr ~in_lhs:false (reads, writes) e'
+  | S.ExprFuncCall (_, stmt) -> collect_stmt (reads, writes) stmt
+
+and collect_stmt (reads, writes) stmt =
+  match stmt with
+  | S.StmExpr (_, e) -> collect_expr ~in_lhs:false (reads, writes) e
+  | S.StmElsif (_, cond, body) ->
+    let acc = collect_stmt (reads, writes) cond in
+    List.fold_left body ~init:acc ~f:collect_stmt
+  | S.StmIf (_, cond, body, elsifs, els) ->
+    let acc = collect_stmt (reads, writes) cond in
+    let acc = List.fold_left body ~init:acc ~f:collect_stmt in
+    let acc = List.fold_left elsifs ~init:acc ~f:collect_stmt in
+    List.fold_left els ~init:acc ~f:collect_stmt
+  | S.StmCase (_, cond, selections, els) ->
+    let acc = collect_stmt (reads, writes) cond in
+    let acc = List.fold_left selections ~init:acc ~f:(fun a (sel : S.case_selection) ->
+        let a = List.fold_left sel.case ~init:a ~f:collect_stmt in
+        List.fold_left sel.body ~init:a ~f:collect_stmt)
+    in
+    List.fold_left els ~init:acc ~f:collect_stmt
+  | S.StmFor (_, fc, body) ->
+    let acc = collect_stmt (reads, writes) fc.assign in
+    let acc = collect_expr ~in_lhs:false acc fc.range_end in
+    let acc = collect_expr ~in_lhs:false acc fc.range_step in
+    List.fold_left body ~init:acc ~f:collect_stmt
+  | S.StmWhile (_, cond, body) ->
+    let acc = collect_stmt (reads, writes) cond in
+    List.fold_left body ~init:acc ~f:collect_stmt
+  | S.StmRepeat (_, body, cond) ->
+    let acc = List.fold_left body ~init:(reads, writes) ~f:collect_stmt in
+    collect_stmt acc cond
+  | S.StmEmpty _ | S.StmExit _ | S.StmContinue _ | S.StmReturn _ ->
+    (reads, writes)
+  | S.StmFuncCall (_, _, params) ->
+    List.fold_left params ~init:(reads, writes) ~f:(fun acc (p : S.func_param_assign) ->
+        collect_stmt acc p.stmt)
+
+
+let get_pou_info elem =
+  match elem with
+  | S.IECFunction (_, fd) ->
+    Some ("function " ^ (S.Function.get_name fd.id), fd.variables, fd.statements)
+  | S.IECFunctionBlock (_, fb) ->
+    Some ("function block " ^ (S.FunctionBlock.get_name fb.id), fb.variables, fb.statements)
+  | S.IECProgram (_, pd) ->
+    Some ("program " ^ pd.name, pd.variables, pd.statements)
+  | _ -> None
+
+type param_kind = PInput | POutput | PInOut
+
+let classify_vardecl vd =
+  match S.VarDecl.get_attr vd with
+  | Some (S.VarDecl.VarIn _) -> Some PInput
+  | Some (S.VarDecl.VarOut _) -> Some POutput
+  | Some S.VarDecl.VarInOut -> Some PInOut
+  | _ -> begin
+      match S.VarDecl.get_direction vd with
+      | Some S.VarDecl.Input -> Some PInput
+      | Some S.VarDecl.Output -> Some POutput
+      | None -> None
+    end
+
+let check_pou elem =
+  match get_pou_info elem with
+  | None -> []
+  | Some (pou_desc, vars, stmts) ->
+    let (reads, writes) =
+      List.fold_left stmts ~init:([], []) ~f:collect_stmt
+    in
+    let read_set = Set.of_list (module String) reads in
+    let write_set = Set.of_list (module String) writes in
+    List.fold_left vars ~init:[] ~f:(fun acc vd ->
+        match classify_vardecl vd with
+        | None -> acc
+        | Some kind ->
+          let name = S.VarDecl.get_var_name vd in
+          let ti = S.VarDecl.get_var_ti vd in
+          let is_read = Set.mem read_set name in
+          let is_written = Set.mem write_set name in
+          let mk_warn msg =
+            W.mk ti.linenr ti.col "PLCOPEN-CP17" msg
+          in
+          begin match kind with
+            | PInput ->
+              let acc =
+                if not is_read then
+                  (mk_warn (Printf.sprintf
+                              "Input parameter '%s' of %s is never read"
+                              name pou_desc)) :: acc
+                else acc
+              in
+              if is_written then
+                (mk_warn (Printf.sprintf
+                            "Input parameter '%s' of %s should not be written"
+                            name pou_desc)) :: acc
+              else acc
+            | POutput ->
+              if not is_written then
+                (mk_warn (Printf.sprintf
+                            "Output parameter '%s' of %s is never written"
+                            name pou_desc)) :: acc
+              else acc
+            | PInOut ->
+              if (not is_read) && (not is_written) then
+                (mk_warn (Printf.sprintf
+                            "In/out parameter '%s' of %s is neither read nor written"
+                            name pou_desc)) :: acc
+              else acc
+          end)
+
+let do_check elems =
+  List.concat_map elems ~f:check_pou
+
+let detector : Detector.t = {
+  id = "PLCOPEN-CP17";
+  name = "Usage of parameters shall match their declaration mode";
+  summary = "Input parameters must be read, output parameters must be written, and in/out parameters must be used.";
+  doc_url = "https://iec-checker.github.io/docs/detectors/PLCOPEN-CP17";
+  check = (fun (i : Detector.inputs) -> do_check i.elements);
+}

--- a/src/lib/plcopen_cp17.mli
+++ b/src/lib/plcopen_cp17.mli
@@ -1,0 +1,5 @@
+(* PLCOPEN-CP17 - Usage of parameters shall match their declaration mode *)
+open IECCheckerCore
+module S = IECCheckerCore.Syntax
+val do_check : S.iec_library_element list -> Warn.t list
+val detector : Detector.t

--- a/test/st/plcopen-cp17.st
+++ b/test/st/plcopen-cp17.st
@@ -1,0 +1,93 @@
+FUNCTION_BLOCK FB_CP17_Test
+VAR_INPUT
+    in_ok_read_only       : INT;   // Compliant: read at least once, never written
+    in_violate_unused     : INT;   // Violation: never read
+    in_violate_write_only : INT;   // Violation: written, not read
+    in_violate_read_write : INT;   // Violation: read but also written
+
+    idx_read_only           : INT;   // Compliant: only read as array index
+    idx_violate_write_only  : INT;   // Violation: written, not read
+END_VAR
+
+VAR_OUTPUT
+    out_ok_written        : INT;   // Compliant: written at least once
+    out_violate_unused    : INT;   // Violation: never written
+    out_violate_read_only : INT;   // Violation: read but not written
+END_VAR
+
+VAR_IN_OUT
+    io_ok_read_only       : INT;   // Compliant: read only
+    io_ok_write_only      : INT;   // Compliant: written only
+    io_ok_read_write      : INT;   // Compliant: both read and written
+    io_violate_unused     : INT;   // Violation: neither read nor written
+END_VAR
+
+VAR
+    temp : INT;
+    arr  : ARRAY[0..9] OF INT;
+END_VAR
+
+
+(* ===== VAR_INPUT tests ===== *)
+
+(* Compliant: input parameter is read *)
+temp := in_ok_read_only + 1;
+
+(* Violation: in_violate_unused is never used *)
+
+(* Violation: input parameter is written *)
+in_violate_write_only := 100;
+
+(* Violation: input parameter is both read and written *)
+temp := in_violate_read_write;
+in_violate_read_write := temp + 1;
+
+
+(* ===== VAR_OUTPUT tests ===== *)
+
+(* Compliant: output parameter is written *)
+out_ok_written := temp;
+
+(* Violation: out_violate_unused is never written *)
+
+(* Violation: output parameter is read but not written *)
+temp := out_violate_read_only;
+
+
+(* ===== VAR_IN_OUT tests ===== *)
+
+(* Compliant: read only *)
+temp := temp + io_ok_read_only;
+
+(* Compliant: written only *)
+io_ok_write_only := 10;
+
+(* Compliant: both read and written *)
+io_ok_read_write := io_ok_read_write + 1;
+
+(* Violation: io_violate_unused is never used *)
+
+(* ===== special tests for LHS handling ===== *)
+
+(* Important case:
+   idx_read_only is used only to locate the write target arr[idx_read_only].
+   It should be counted as READ, not WRITE. 
+   However, *)
+arr[idx_read_only] := 5;
+
+(* Violation:
+   idx_violate_write_only is written, but never read. *)
+idx_violate_write_only := 3;
+
+END_FUNCTION_BLOCK
+
+(*
+ * The reported result should be:
+ * 1. in_violate_unused => should be read
+ * 2. in_violate_write_only => should not be written, should be read (2 * warnings reported)
+ * 3. in_violate_read_write => should not be written
+ * 4. out_violate_unused => should be written
+ * 5. out_violate_read_only => should be written
+ * 6. io_violate_unused => should be written/read
+ * 7. idx_violate_write_only => should not be written, should be read (2 * warnings reported)
+*)

--- a/test/st/plcopen-cp17.st
+++ b/test/st/plcopen-cp17.st
@@ -7,6 +7,9 @@ VAR_INPUT
 
     idx_read_only           : INT;   // Compliant: only read as array index
     idx_violate_write_only  : INT;   // Violation: written, not read
+    func_violate_unused     : INT;   // Violation: never use
+    func_read_only          : INT;   // Compliant: only read in func call
+    func_violate_write      : INT;   // Violation: written in func call
 END_VAR
 
 VAR_OUTPUT
@@ -25,6 +28,7 @@ END_VAR
 VAR
     temp : INT;
     arr  : ARRAY[0..9] OF INT;
+    func : MYFUNC;
 END_VAR
 
 
@@ -79,6 +83,9 @@ arr[idx_read_only] := 5;
    idx_violate_write_only is written, but never read. *)
 idx_violate_write_only := 3;
 
+(* Function Call *)
+func(func_violate_unused := func_read_only, func_violate_unused => func_violate_write);
+
 END_FUNCTION_BLOCK
 
 (*
@@ -90,4 +97,6 @@ END_FUNCTION_BLOCK
  * 5. out_violate_read_only => should be written
  * 6. io_violate_unused => should be written/read
  * 7. idx_violate_write_only => should not be written, should be read (2 * warnings reported)
+ * 8. func_violate_unused => never used, should be read
+ * 9. func_violate_write => should not be written, should be read (2 * warnings reported)
 *)

--- a/test/test_plcopen.py
+++ b/test/test_plcopen.py
@@ -110,6 +110,29 @@ def test_cp16():
         pass
 
 
+def test_cp17():
+    f = 'st/plcopen-cp17.st'
+    fdump = f'{f}.dump.json'
+    warns, rc = run_checker([f])
+    assert rc == 0
+    cp17_warns = filter_warns(warns, 'PLCOPEN-CP17')
+    assert len(cp17_warns) == 13
+    expected_warnings = [
+        (4, 21), (5, 25), (5, 25), (6, 25), (8, 17), (9, 26), (9, 26),
+        (10, 23), (12, 22), (12, 22), (17, 22), (18, 25), (25, 21)
+    ]
+    
+    for linenr, column in expected_warnings:
+        assert any(
+            w.linenr == linenr and 
+            w.column == column
+            for w in cp17_warns
+        ), f"Expected warning at line {linenr}, column {column} not found"
+    
+    with DumpManager(fdump):
+        pass
+
+
 def test_cp26():
     f = 'st/plcopen-cp26.st'
     fdump = f'{f}.dump.json'


### PR DESCRIPTION
## PLCOPEN-CP17 

In PLCopen coding guideline document, PLCOPEN-CP17 is defined as follows:

**PLCOPEN-CP17:** Usage of parameters shall match their declaration mode.
**Description:** The parameters declared as input shall be read, the parameters declared as output shall be written and the parameters declared as in/out shall be read and written. 
**Guideline:** The mode of a parameter (input, output or input/output) should reflect the usage of the parameter in the corresponding POU. The following rules apply: 

- Each input parameter should be read at least once in the POU code 
- Each input parameter should not be written in the POU code 
- Each output parameter should be written at least once in the POU code 
- Each input/output parameter should be either read or written in the POU code 

**Reasoning:** Not using the parameters declared in the POU interface is a loss of time for the developers and for the machine performance. Using the parameter in the wrong way may lead to side effects when the Programming Support Environment doesn't limit the usage. 
**Exceptions:** None

## Comment & Explanation

This PR submitted a new detector for PLCOPEN-CP17 rule and a corresponding .st file as test case.

However, due to the implementation of current parser/CST definition, we got an explicit trouble in the new detector.
In IEC 61131-3, the formal definitions related to "Subscript Variable Access" are:
```ebnf
Symbolic_Variable  : ( ( 'THIS' '.' ) | Namespace_Hierarchy '.' )? ( Var_Access | Multi_Elem_Var );
Var_Access         : Variable_Name | Ref_Deref; 
Multi_Elem_Var     : Var_Access (Subscript_List | Struct_Variable)+;
Subscript_List     : '[' Subscript ( ',' Subscript )* ']';
Subscript          : Expression;
...
```
So theoretically, all variables in a `Subscript` should all be tagged to "read".
But currently the parser has discarded all variables in the `Subscript` inside the `[]` when it is not a constant, thus the detector cannot distinguish the read/write of the variables in the `Subscript`:
```mly
(* a code segment from parser.mly *)
let multi_elem_var :=
  | name_ti = var_access; T_LBRACK; sub_list = subscript_list; T_RBRACK;
  {
   let (name, ti) = name_ti in
   let sv = Syntax.SymVar.create name ti in
   (* Add array indexes to variable. *)
   List.fold_left
     sub_list
     ~init:sv
     ~f:(fun acc_sv e -> begin
         match e with
         | Syntax.ExprConstant (_,c) -> begin
           let val_opt = c_get_int c in
           match val_opt with
           | Some v -> Syntax.SymVar.add_array_index acc_sv v
           | None -> Syntax.SymVar.add_array_index_opaque acc_sv
         end
         | _ -> Syntax.SymVar.add_array_index_opaque acc_sv
     end)
  }
  (* | ~ = var_access; sub_list = nonempty_list(struct_variable); *)

let subscript_list :=
 | s = subscript;
 { [s] }
 | vs = subscript_list; T_COMMA; s = subscript;
 { List.append vs [s] }

let subscript :=
  | e = expression; <>
```

This is a question worth discussing.